### PR TITLE
Add Vault policy for reading postgres secrets

### DIFF
--- a/terraform/vault/policies.tf
+++ b/terraform/vault/policies.tf
@@ -7,3 +7,8 @@ resource "vault_policy" "cloudflare_reader" {
   name   = "cloudflare-reader"
   policy = file("${path.module}/policies/cloudflare-reader-policy.hcl")
 }
+
+resource "vault_policy" "postgres_reader" {
+  name   = "postgres-reader"
+  policy = file("${path.module}/policies/postgres-reader-policy.hcl")
+}

--- a/terraform/vault/policies/postgres-reader-policy.hcl
+++ b/terraform/vault/policies/postgres-reader-policy.hcl
@@ -1,0 +1,4 @@
+# Allow reading cloudflare credentials
+path "postgres/*" {
+  capabilities = ["read"]
+}

--- a/terraform/vault/roles.tf
+++ b/terraform/vault/roles.tf
@@ -7,5 +7,6 @@ resource "vault_token_auth_backend_role" "nomad_cluster" {
   renewable              = true
   allowed_policies = [
     vault_policy.cloudflare_reader.name,
+    vault_policy.postgres_reader.name,
   ]
 }


### PR DESCRIPTION
This commit adds a vault policy that will allow nomad to issue
postgres credentials to workloads.

Signed-off-by: David Bond <davidsbond93@gmail.com>