### PR TITLE
Run 2 instances of pihole on different hosts

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,9 +5,11 @@ on:
       - master
     paths:
       - '**.tf'
+      - '**.nomad'
   pull_request:
     paths:
       - '**.tf'
+      - '**.nomad'
 
 jobs:
   format:

--- a/terraform/nomad/jobs/pihole.nomad
+++ b/terraform/nomad/jobs/pihole.nomad
@@ -1,10 +1,15 @@
 job "pihole" {
   region      = "global"
   datacenters = ["homad"]
-  type        = "system"
+  type        = "service"
 
   group "pihole" {
-    count = 1
+    count = 2
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
 
     ephemeral_disk {
       migrate = true


### PR DESCRIPTION
This commit modifies the pihole installation from a system job to a
service job. Instead of running on each node it instead runs 2
instances on distrinct hosts.

Signed-off-by: David Bond <davidsbond93@gmail.com>