### PR TITLE
Add update strategies for pihole and traefik

### DIFF
--- a/terraform/nomad/jobs/pihole.nomad
+++ b/terraform/nomad/jobs/pihole.nomad
@@ -6,6 +6,10 @@ job "pihole" {
   group "pihole" {
     count = 2
 
+    update {
+      max_parallel = 1
+    }
+
     constraint {
       operator = "distinct_hosts"
       value    = "true"
@@ -35,7 +39,8 @@ job "pihole" {
         "traefik.enable=true",
         "traefik.http.routers.pihole.rule=Host(`pihole.homelab.dsb.dev`)",
         "traefik.http.routers.pihole.entrypoints=https",
-        "traefik.http.routers.pihole.tls.certresolver=cloudflare"
+        "traefik.http.routers.pihole.tls.certresolver=cloudflare",
+        "traefik.http.services.pihole.loadBalancer.sticky.cookie.name=pihole"
       ]
 
       check {

--- a/terraform/nomad/jobs/traefik.nomad
+++ b/terraform/nomad/jobs/traefik.nomad
@@ -6,6 +6,10 @@ job "traefik" {
   group "traefik" {
     count = 1
 
+    update {
+      max_parallel = 1
+    }
+
     network {
       port "http" {
         static = 80
@@ -38,7 +42,8 @@ job "traefik" {
         "traefik.enable=true",
         "traefik.http.routers.traefik.rule=Host(`traefik.homelab.dsb.dev`)",
         "traefik.http.routers.traefik.entrypoints=https",
-        "traefik.http.routers.traefik.tls.certresolver=cloudflare"
+        "traefik.http.routers.traefik.tls.certresolver=cloudflare",
+        "traefik.http.services.traefik.loadBalancer.sticky.cookie.name=traefik"
       ]
 
       check {


### PR DESCRIPTION
This commit adds update strategies for pihole and traefik, making only one
task be updated at a time. It also adds sticky sessions for pihole and
traefik so that clients will hit the same instance each time (providing they
keep the cookie)

Signed-off-by: David Bond <davidsbond93@gmail.com>