### PR TITLE
Automatically add new nomad clients

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,5 +1,7 @@
 name: terraform
 on:
+  schedule:
+    - cron: '0 * * * *'
   push:
     branches:
       - master
@@ -25,6 +27,7 @@ jobs:
         run: make format
 
   plan:
+    concurrency: terraform
     needs:
       - format
     runs-on: ubuntu-20.04
@@ -66,10 +69,11 @@ jobs:
           retention-days: 3
 
   apply:
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/master'
+    concurrency: terraform
     needs:
       - plan
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0

--- a/terraform/tailscale/devices.tf
+++ b/terraform/tailscale/devices.tf
@@ -1,15 +1,7 @@
-data "tailscale_device" "homad_1" {
-  name = "homad-1.davidsbond93.gmail.com"
-}
-
-data "tailscale_device" "homad_2" {
-  name = "homad-2.davidsbond93.gmail.com"
-}
-
-data "tailscale_device" "homad_3" {
-  name = "homad-3.davidsbond93.gmail.com"
-}
-
 data "tailscale_device" "nas" {
   name = "home-nas.davidsbond93.gmail.com"
+}
+
+data "tailscale_devices" "nomad_clients" {
+  name_prefix = "homad-"
 }

--- a/terraform/tailscale/output.tf
+++ b/terraform/tailscale/output.tf
@@ -1,8 +1,9 @@
+# homad-0 is the server node, so it won't be serving any traffic, we want to get all tailscale devices whose
+# names are prefixed with "homad-", filter out "homad-0" and return the first address for each node.
 output "homelab_clients" {
   value = [
-    element(data.tailscale_device.homad_1.addresses, 0),
-    element(data.tailscale_device.homad_2.addresses, 0),
-    element(data.tailscale_device.homad_3.addresses, 0),
+    for client in data.tailscale_devices.nomad_clients.devices : element(client.addresses, 0)
+    if client.name != "homad-0.davidsbond93.gmail.com"
   ]
 }
 


### PR DESCRIPTION
This commit modifies the CI pipeline to reapply the configuration every hour,
it also changes the tailscale query to look up all devices with a "homad-"
prefix and add them to the DNS records. This should mean that when new clients
are added, provided they use the correct naming format, will automatically have
their DNS records set up every hour.

This should just work as the traefik deployment is set up as a system job, so
each client will get a traefik instance once they're ready.

Signed-off-by: David Bond <davidsbond93@gmail.com>