### PR TITLE
Add pihole-reader policy to nomad role

### DIFF
--- a/terraform/vault/roles.tf
+++ b/terraform/vault/roles.tf
@@ -8,5 +8,6 @@ resource "vault_token_auth_backend_role" "nomad_cluster" {
   allowed_policies = [
     vault_policy.cloudflare_reader.name,
     vault_policy.postgres_reader.name,
+    vault_policy.pihole_reader.name,
   ]
 }


### PR DESCRIPTION
This commit allows nomad to provide jobs the ability to read
pihole credentials.

Signed-off-by: David Bond <davidsbond93@gmail.com>