### PR TITLE
Setup DNS over HTTPs for Pihole

### DIFF
--- a/terraform/consul/cloudflared.tf
+++ b/terraform/consul/cloudflared.tf
@@ -1,0 +1,8 @@
+resource "consul_key_prefix" "cloudflared" {
+  path_prefix = "homad/cloudflared/"
+  subkeys = {
+    "TUNNEL_DNS_ADDRESS"  = "0.0.0.0"
+    "TUNNEL_DNS_PORT"     = "5053"
+    "TUNNEL_DNS_UPSTREAM" = " https://1.1.1.1/dns-query,https://1.0.0.1/dns-query"
+  }
+}

--- a/terraform/consul/pihole.tf
+++ b/terraform/consul/pihole.tf
@@ -2,8 +2,7 @@ resource "consul_key_prefix" "pihole" {
   path_prefix = "homad/pihole/"
   subkeys = {
     "TZ"           = "Europe/London"
-    "DNS1"         = "8.8.8.8"
-    "DNS2"         = "8.8.4.4"
+    "DNS1"         = "127.0.0.1#5053"
     "VIRTUAL_HOST" = "pihole.homelab.dsb.dev"
   }
 }

--- a/terraform/nomad/jobs/pihole.nomad
+++ b/terraform/nomad/jobs/pihole.nomad
@@ -98,5 +98,32 @@ EOT
 EOT
       }
     }
+
+    task "cloudflared" {
+      driver = "docker"
+
+      config {
+        image   = "raspbernetes/cloudflared:2022.5.1"
+        command = "cloudflared"
+        args = [
+          "--no-autoupdate",
+          "--proxy-dns"
+        ]
+      }
+
+      logs {
+        max_files = 1
+      }
+
+      template {
+        destination = "local/cloudflared.env"
+        env         = true
+        data        = <<EOT
+{{ range ls "homad/cloudflared" }}
+{{.Key}}={{.Value}}
+{{ end }}
+EOT
+      }
+    }
   }
 }


### PR DESCRIPTION
This commit sets up cloudflared alongside pihole which is used to
get DNS over HTTPs.

Signed-off-by: David Bond <davidsbond93@gmail.com>