### PR TITLE
Set up traefik routing for postgres

### DIFF
--- a/terraform/consul/files/traefik/traefik.yaml
+++ b/terraform/consul/files/traefik/traefik.yaml
@@ -19,10 +19,15 @@ entryPoints:
         entryPoint:
           to: https
           scheme: https
+
   https:
     address: :443
+
   ping:
     address: :8082
+
+  postgres:
+    address: :5432
 
 ping:
   entryPoint: ping

--- a/terraform/nomad/jobs/postgres.nomad
+++ b/terraform/nomad/jobs/postgres.nomad
@@ -21,6 +21,13 @@ job "postgres" {
       port = "postgres"
       task = "postgres"
 
+      tags = [
+        "traefik.enable=true",
+        "traefik.tcp.routers.postgres.entrypoints=postgres",
+        "traefik.tcp.routers.postgres.rule=HostSNI(`*`)",
+        "traefik.tcp.services.postgres.loadBalancer.server.port=${NOMAD_HOST_PORT_postgres}"
+      ]
+
       check {
         type     = "tcp"
         port     = "postgres"
@@ -45,6 +52,11 @@ job "postgres" {
         volumes = [
           "local/data:/data"
         ]
+      }
+
+      resources {
+        memory     = 1024
+        memory_max = 2048
       }
 
       template {

--- a/terraform/nomad/jobs/traefik.nomad
+++ b/terraform/nomad/jobs/traefik.nomad
@@ -79,7 +79,7 @@ job "traefik" {
         volumes = [
           "local/traefik.yaml:/etc/traefik/traefik.yaml",
           "local/external.yaml:/etc/traefik/common/external.yaml",
-          "secrets/letsencrypt:/letsencrypt"
+          "local/letsencrypt:/letsencrypt"
         ]
       }
 


### PR DESCRIPTION
This commit sets up traefik so that we can connect to it via a hostname. It also
modifies traefik to store ACME certs in the local directory so that it is migrated
on redeployments.

Signed-off-by: David Bond <davidsbond93@gmail.com>