### PR TITLE
Add NFS CSI and set up jobs to use it

### DIFF
--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -17,3 +17,11 @@ resource "nomad_job" "pihole" {
 resource "nomad_job" "postgres" {
   jobspec = file("${path.module}/jobs/postgres.nomad")
 }
+
+resource "nomad_job" "storage_controller" {
+  jobspec = file("${path.module}/jobs/csi/controller.nomad")
+}
+
+resource "nomad_job" "storage_node" {
+  jobspec = file("${path.module}/jobs/csi/node.nomad")
+}

--- a/terraform/nomad/jobs/bitwarden.nomad
+++ b/terraform/nomad/jobs/bitwarden.nomad
@@ -10,6 +10,14 @@ job "bitwarden" {
       }
     }
 
+    volume "bitwarden" {
+      type            = "csi"
+      source          = "bitwarden"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
     ephemeral_disk {
       migrate = true
       size    = 100
@@ -42,14 +50,15 @@ job "bitwarden" {
       config {
         image = "vaultwarden/server:1.24.0"
         ports = ["bitwarden"]
-
-        volumes = [
-          "local/data:/data"
-        ]
       }
 
       logs {
         max_files = 1
+      }
+
+      volume_mount {
+        volume      = "bitwarden"
+        destination = "/data"
       }
     }
   }

--- a/terraform/nomad/jobs/csi/controller.nomad
+++ b/terraform/nomad/jobs/csi/controller.nomad
@@ -1,0 +1,30 @@
+job "storage-controller" {
+  datacenters = ["homad"]
+  type        = "service"
+
+  group "controller" {
+    task "controller" {
+      driver = "docker"
+
+      config {
+        image = "registry.gitlab.com/rocketduck/csi-plugin-nfs:0.4.0"
+
+        args = [
+          "--type=controller",
+          "--node-id=${attr.unique.hostname}",
+          "--nfs-server=192.168.0.22:/volume1/homad",
+          "--mount-options=defaults",
+        ]
+
+        network_mode = "host"
+        privileged   = true
+      }
+
+      csi_plugin {
+        id        = "nfs"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+    }
+  }
+}

--- a/terraform/nomad/jobs/csi/node.nomad
+++ b/terraform/nomad/jobs/csi/node.nomad
@@ -1,0 +1,30 @@
+job "storage-node" {
+  datacenters = ["homad"]
+  type        = "system"
+
+  group "node" {
+    task "node" {
+      driver = "docker"
+
+      config {
+        image = "registry.gitlab.com/rocketduck/csi-plugin-nfs:0.4.0"
+
+        args = [
+          "--type=node",
+          "--node-id=${attr.unique.hostname}",
+          "--nfs-server=192.168.0.22:/volume1/homad",
+          "--mount-options=defaults",
+        ]
+
+        network_mode = "host"
+        privileged   = true
+      }
+
+      csi_plugin {
+        id        = "nfs"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+    }
+  }
+}

--- a/terraform/nomad/jobs/home-assistant.nomad
+++ b/terraform/nomad/jobs/home-assistant.nomad
@@ -10,6 +10,14 @@ job "homeassistant" {
       }
     }
 
+    volume "home-assistant" {
+      type            = "csi"
+      source          = "home-assistant"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
     ephemeral_disk {
       migrate = true
       size    = 100
@@ -49,9 +57,13 @@ job "homeassistant" {
           "local/groups.yaml:/config/groups.yaml",
           "local/scenes.yaml:/config/scenes.yaml",
           "local/scripts.yaml:/config/scripts.yaml",
-          "local/ui-lovelace.yaml:/config/ui-lovelace.yaml",
-          "local/storage:/config/.storage"
+          "local/ui-lovelace.yaml:/config/ui-lovelace.yaml"
         ]
+      }
+
+      volume_mount {
+        volume      = "home-assistant"
+        destination = "/config/.storage"
       }
 
       logs {

--- a/terraform/nomad/jobs/postgres.nomad
+++ b/terraform/nomad/jobs/postgres.nomad
@@ -10,6 +10,14 @@ job "postgres" {
       }
     }
 
+    volume "postgres" {
+      type            = "csi"
+      source          = "postgres"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
     ephemeral_disk {
       migrate = true
       size    = 1024
@@ -48,10 +56,11 @@ job "postgres" {
       config {
         image = "postgres:13"
         ports = ["postgres"]
+      }
 
-        volumes = [
-          "local/data:/data"
-        ]
+      volume_mount {
+        volume      = "postgres"
+        destination = "/data"
       }
 
       resources {

--- a/terraform/nomad/jobs/traefik.nomad
+++ b/terraform/nomad/jobs/traefik.nomad
@@ -1,13 +1,26 @@
 job "traefik" {
   region      = "global"
   datacenters = ["homad"]
-  type        = "system"
+  type        = "service"
 
   group "traefik" {
-    count = 1
+    count = 3
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
 
     update {
       max_parallel = 1
+    }
+
+    volume "traefik" {
+      type            = "csi"
+      source          = "traefik"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
     }
 
     network {
@@ -78,9 +91,13 @@ job "traefik" {
 
         volumes = [
           "local/traefik.yaml:/etc/traefik/traefik.yaml",
-          "local/external.yaml:/etc/traefik/common/external.yaml",
-          "local/letsencrypt:/letsencrypt"
+          "local/external.yaml:/etc/traefik/common/external.yaml"
         ]
+      }
+
+      volume_mount {
+        volume      = "traefik"
+        destination = "/letsencrypt"
       }
 
       template {


### PR DESCRIPTION
THis commit includes the jobs required for an NFS CSI driver. It
also modifies my workloads to use CSI persistence instead of relying
on sticky ephemeral disks.

Signed-off-by: David Bond <davidsbond93@gmail.com>