### PR TITLE
Set up home-assistant recorder/history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # homad
 
 This repository contains all the configuration of my [HashiCorp Nomad](https://nomadproject.io) deployment in my
-home server-rack. It is deployed in a high-availability configuration using both [HashiCorp Vault](https://www.vaultproject.io/) 
+home server-rack. It is deployed in a high-availability configuration using both [HashiCorp Vault](https://www.vaultproject.io/)
 and [HashiCorp Consul](https://www.consul.io/).
 
-Everything within this repository is managed using [Terraform](https://www.terraform.io/), including deployment of 
-workloads in Nomad.
+Everything within this repository is managed using [Terraform](https://www.terraform.io/), including deployment of
+workloads in Nomad. Terraform source files are organised by provider within the [terraform](./terraform) directory.
 
 ## Workloads
 
@@ -13,7 +13,14 @@ To see all my Nomad job specifications, check the [jobs](terraform/nomad/jobs) d
 
 Within my Nomad cluster, I run the following services:
 
-* [Traefik](https://traefik.io/) - Reverse proxy & load balancer that allows me to access my applications and issue TLS certificates
-* [PiHole](https://pi-hole.net/) - DNS & Adblocker that I use on my networked devices at home
-* [Home Assistant](https://www.home-assistant.io/) - IoT integration suite that allows me to manage & automate my smart devices
 * [Bitwarden](https://bitwarden.com/) - Password manager
+* [Home Assistant](https://www.home-assistant.io/) - IoT integration suite that allows me to manage & automate my smart devices
+* [PiHole](https://pi-hole.net/) - DNS & Adblocker that I use on my networked devices at home
+* [Postgres](https://www.postgresql.org/) - SQL database for services that need one
+* [Traefik](https://traefik.io/) - Reverse proxy & load balancer that allows me to access my applications and issue TLS certificates
+
+## CI
+
+Merges to the `master` branch will automatically plan and apply changes to terraform files by first connecting the
+GitHub action to my [Tailscale](https://tailscale.com/) tailnet. For pull requests, a plan is performed which can be checked within the
+GitHub action log.

--- a/terraform/consul/files/home-assistant/configuration.yaml
+++ b/terraform/consul/files/home-assistant/configuration.yaml
@@ -15,9 +15,6 @@ mobile_app:
 # Enable system health
 system_health:
 
-# Checks for available updates
-updater:
-
 # Discover some devices automatically
 discovery:
 
@@ -30,3 +27,11 @@ http:
   use_x_forwarded_for: true
   trusted_proxies:
     - 192.168.0.0/24
+
+# Set up recording with sqlite
+recorder:
+  db_url: sqlite:////config/.storage/recorder.db
+  purge_keep_days: 7
+
+# Enable history with recorder
+history:


### PR DESCRIPTION
This commit modifies home-assistant to use sqlite as a persistent
store for the recorder/history plugins.

Signed-off-by: David Bond <davidsbond93@gmail.com>