### PR TITLE
Enable DNS over TLS using cloudflared

### DIFF
--- a/terraform/consul/pihole.tf
+++ b/terraform/consul/pihole.tf
@@ -1,9 +1,9 @@
 resource "consul_key_prefix" "pihole" {
   path_prefix = "homad/pihole/"
   subkeys = {
-    "TZ"           = "Europe/London"
-    "DNS1"         = "8.8.8.8"
-    "DNS2"         = "8.8.4.4"
-    "VIRTUAL_HOST" = "pihole.homelab.dsb.dev"
+    "TZ"            = "Europe/London"
+    "VIRTUAL_HOST"  = "pihole.homelab.dsb.dev"
+    "DNSSEC"        = "true"
+    "QUERY_LOGGING" = "true"
   }
 }


### PR DESCRIPTION
This commit sets up cloudflared as a sidecar for the pihole so that we
can do DNS over TLS. It also enables DNSSEC on the pihole.

Signed-off-by: David Bond <davidsbond93@gmail.com>