### PR TITLE
Add dashboards for internet & lighting to home-assistant

### DIFF
--- a/terraform/consul/files/home-assistant/configuration.yaml
+++ b/terraform/consul/files/home-assistant/configuration.yaml
@@ -21,6 +21,19 @@ discovery:
 # Enable yaml based dashboards
 lovelace:
   mode: yaml
+  dashboards:
+    homelab-internet:
+      mode: yaml
+      filename: ui-internet.yaml
+      title: Internet
+      icon: mdi:wifi
+      show_in_sidebar: true
+    homelab-lighting:
+      mode: yaml
+      filename: ui-lighting.yaml
+      title: Lighting
+      icon: mdi:lightbulb
+      show_in_sidebar: true
 
 # Allow reverse proxies
 http:

--- a/terraform/consul/files/home-assistant/ui-internet.yaml
+++ b/terraform/consul/files/home-assistant/ui-internet.yaml
@@ -1,0 +1,48 @@
+title: Internet
+views:
+  - title: SpeedTest
+    path: speed-test
+    theme: ''
+    badges: []
+    cards:
+      - type: sensor
+        entity: sensor.speedtest_ping
+        graph: line
+      - type: sensor
+        entity: sensor.speedtest_download
+        graph: line
+      - type: sensor
+        entity: sensor.speedtest_upload
+        graph: line
+  - title: PiHole
+    path: pi-hole
+    theme: ''
+    badges: []
+    cards:
+      - type: sensor
+        entity: sensor.pi_hole_ads_blocked_today
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_ads_percentage_blocked_today
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_seen_clients
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_dns_unique_clients
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_dns_queries_today
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_domains_blocked
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_dns_queries_cached
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_dns_queries_forwarded
+        graph: line
+      - type: sensor
+        entity: sensor.pi_hole_dns_unique_domains
+        graph: line

--- a/terraform/consul/files/home-assistant/ui-lighting.yaml
+++ b/terraform/consul/files/home-assistant/ui-lighting.yaml
@@ -1,0 +1,31 @@
+title: Lighting
+views:
+  - title: Lights
+    path: lights
+    theme: ''
+    badges: []
+    cards:
+      - type: light
+        entity: light.bedroom_lamp
+        double_tap_action:
+          action: toggle
+      - type: light
+        entity: light.hallway_light
+        double_tap_action:
+          action: toggle
+      - type: light
+        entity: light.landing_light
+        double_tap_action:
+          action: toggle
+      - type: light
+        entity: light.living_room_light
+        double_tap_action:
+          action: toggle
+      - type: light
+        entity: light.office_light
+        double_tap_action:
+          action: toggle
+      - type: light
+        entity: light.spare_bedroom_lamp
+        double_tap_action:
+          action: toggle

--- a/terraform/consul/home-assistant.tf
+++ b/terraform/consul/home-assistant.tf
@@ -7,5 +7,7 @@ resource "consul_key_prefix" "home_assistant" {
     "scenes.yaml"        = file("${path.module}/files/home-assistant/scenes.yaml")
     "scripts.yaml"       = file("${path.module}/files/home-assistant/scripts.yaml")
     "ui-lovelace.yaml"   = file("${path.module}/files/home-assistant/ui-lovelace.yaml")
+    "ui-internet.yaml"   = file("${path.module}/files/home-assistant/ui-internet.yaml")
+    "ui-lighting.yaml"   = file("${path.module}/files/home-assistant/ui-lighting.yaml")
   }
 }

--- a/terraform/nomad/jobs/home-assistant.nomad
+++ b/terraform/nomad/jobs/home-assistant.nomad
@@ -18,12 +18,6 @@ job "homeassistant" {
       access_mode     = "multi-node-multi-writer"
     }
 
-    ephemeral_disk {
-      migrate = true
-      size    = 100
-      sticky  = true
-    }
-
     service {
       name = "homeassistant"
       port = "homeassistant"
@@ -64,6 +58,8 @@ job "homeassistant" {
           "local/scenes.yaml:/config/scenes.yaml",
           "local/scripts.yaml:/config/scripts.yaml",
           "local/ui-lovelace.yaml:/config/ui-lovelace.yaml",
+          "local/ui-internet.yaml:/config/ui-internet.yaml",
+          "local/ui-lighting.yaml:/config/ui-lighting.yaml",
           "secrets/secrets.yaml:/config/secrets.yaml"
         ]
       }
@@ -116,6 +112,20 @@ EOT
         destination = "local/ui-lovelace.yaml"
         data        = <<EOT
 {{- key "homad/home-assistant/ui-lovelace.yaml" }}
+EOT
+      }
+
+      template {
+        destination = "local/ui-internet.yaml"
+        data        = <<EOT
+{{- key "homad/home-assistant/ui-internet.yaml" }}
+EOT
+      }
+
+      template {
+        destination = "local/ui-lighting.yaml"
+        data        = <<EOT
+{{- key "homad/home-assistant/ui-lighting.yaml" }}
 EOT
       }
 


### PR DESCRIPTION
This commit adds 2 new dashboards to home-assistant that describe
the lighting and internet setup.

Signed-off-by: David Bond <davidsbond93@gmail.com>