### PR TITLE
Upgrade docker images

### DIFF
--- a/terraform/nomad/jobs/bitwarden.nomad
+++ b/terraform/nomad/jobs/bitwarden.nomad
@@ -48,7 +48,7 @@ job "bitwarden" {
       driver = "docker"
 
       config {
-        image = "vaultwarden/server:1.24.0"
+        image = "vaultwarden/server:1.25.0"
         ports = ["bitwarden"]
       }
 

--- a/terraform/nomad/jobs/boundary.nomad
+++ b/terraform/nomad/jobs/boundary.nomad
@@ -28,7 +28,7 @@ job "boundary" {
       driver = "docker"
 
       config {
-        image   = "hashicorp/boundary:0.8.1"
+        image   = "hashicorp/boundary:0.9.0"
         command = "database"
         args = [
           "init",

--- a/terraform/nomad/jobs/grafana.nomad
+++ b/terraform/nomad/jobs/grafana.nomad
@@ -27,7 +27,7 @@ job "grafana" {
       }
 
       config {
-        image = "grafana/grafana:8.5.3"
+        image = "grafana/grafana:9.0.2"
         ports = ["grafana"]
       }
 

--- a/terraform/nomad/jobs/home-assistant.nomad
+++ b/terraform/nomad/jobs/home-assistant.nomad
@@ -48,7 +48,7 @@ job "homeassistant" {
       }
 
       config {
-        image = "homeassistant/home-assistant:2022.5"
+        image = "homeassistant/home-assistant:2022.6"
         ports = ["homeassistant"]
 
         volumes = [

--- a/terraform/nomad/jobs/pihole.nomad
+++ b/terraform/nomad/jobs/pihole.nomad
@@ -78,7 +78,7 @@ job "pihole" {
       }
 
       config {
-        image = "pihole/pihole:2022.04.3"
+        image = "pihole/pihole:2022.05"
         ports = [
           "dns",
           "pihole"
@@ -138,7 +138,7 @@ EOT
       }
 
       config {
-        image = "raspbernetes/cloudflared:2022.5.1"
+        image = "raspbernetes/cloudflared:2022.7.0"
         ports = ["cloudflared"]
 
         args = [

--- a/terraform/nomad/jobs/traefik.nomad
+++ b/terraform/nomad/jobs/traefik.nomad
@@ -82,7 +82,7 @@ job "traefik" {
       }
 
       config {
-        image        = "traefik:v2.7"
+        image        = "traefik:v2.8"
         network_mode = "host"
 
         args = [


### PR DESCRIPTION
This commit updates available docker images to latest versions:

* Bitwarden: 1.24.0 -> 1.25.0
* Boundary: 0.8.1 -> 0.9.0
* Grafana: 8.5.3 -> 9.0.2
* Home Assistant: 2022.5 -> 2022.6
* PiHole: 2022.04.3 -> 2022.05
* Traefik: 2.7 -> 2.8
* Cloudflared: 2022.5.1 -> 2022.7.0

Signed-off-by: David Bond <davidsbond93@gmail.com>