### PR TITLE
Add daily job to keep ubuntu up-to-date

### DIFF
--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -37,3 +37,7 @@ resource "nomad_job" "boundary" {
 resource "nomad_job" "minio" {
   jobspec = file("${path.module}/jobs/minio.nomad")
 }
+
+resource "nomad_job" "ubuntu_upgrade" {
+  jobspec = file("${path.module}/jobs/ubuntu-upgrade.nomad")
+}

--- a/terraform/nomad/jobs/ubuntu-upgrade.nomad
+++ b/terraform/nomad/jobs/ubuntu-upgrade.nomad
@@ -1,0 +1,60 @@
+job "ubuntu-upgrade" {
+  datacenters = ["homad"]
+  type        = "sysbatch"
+  region      = "global"
+
+  periodic {
+    cron             = "@daily"
+    prohibit_overlap = true
+  }
+
+  group "distribution" {
+    task "dist-upgrade" {
+      driver = "raw_exec"
+
+      config {
+        command = "apt-get"
+        args    = ["dist-upgrade"]
+      }
+    }
+  }
+
+  group "packages" {
+    task "update" {
+      driver = "raw_exec"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      config {
+        command = "apt-get"
+        args    = ["update"]
+      }
+    }
+
+    task "upgrade" {
+      driver = "raw_exec"
+
+      config {
+        command = "apt-get"
+        args    = ["upgrade"]
+      }
+    }
+
+    task "autoremove" {
+      driver = "raw_exec"
+
+      lifecycle {
+        hook    = "poststop"
+        sidecar = false
+      }
+
+      config {
+        command = "apt-get"
+        args    = ["autoremove"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a sysbatch job that will periodically run updates for ubuntu
packages and the distribution itself. The version of ubuntu on my homelab fell
into EOF which was a massive pain to upgrade involving lots of manual steps. This
job should keep the clients on an LTS version of ubuntu as well as keeping other system
packages up-to-date.

Signed-off-by: David Bond <davidsbond93@gmail.com>