### PR TITLE
Modify garbage collection jobs

### DIFF
--- a/terraform/nomad/jobs/maintenance/docker-gc.nomad
+++ b/terraform/nomad/jobs/maintenance/docker-gc.nomad
@@ -4,7 +4,7 @@ job "docker-gc" {
   region      = "global"
 
   periodic {
-    cron             = "@hourly"
+    cron             = "@daily"
     prohibit_overlap = true
   }
 

--- a/terraform/nomad/jobs/maintenance/journalctl-gc.nomad
+++ b/terraform/nomad/jobs/maintenance/journalctl-gc.nomad
@@ -4,7 +4,7 @@ job "journalctl-gc" {
   region      = "global"
 
   periodic {
-    cron             = "@hourly"
+    cron             = "@daily"
     prohibit_overlap = true
   }
 

--- a/terraform/nomad/jobs/maintenance/nomad-gc.nomad
+++ b/terraform/nomad/jobs/maintenance/nomad-gc.nomad
@@ -4,7 +4,7 @@ job "nomad-gc" {
   region      = "global"
 
   periodic {
-    cron             = "@hourly"
+    cron             = "@daily"
     prohibit_overlap = true
   }
 

--- a/terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad
+++ b/terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad
@@ -14,7 +14,7 @@ job "ubuntu-upgrade" {
 
       config {
         command = "apt-get"
-        args    = ["dist-upgrade"]
+        args    = ["dist-upgrade", "-y"]
       }
     }
   }
@@ -39,7 +39,7 @@ job "ubuntu-upgrade" {
 
       config {
         command = "apt-get"
-        args    = ["upgrade"]
+        args    = ["upgrade", "-y"]
       }
     }
 
@@ -53,7 +53,7 @@ job "ubuntu-upgrade" {
 
       config {
         command = "apt-get"
-        args    = ["autoremove"]
+        args    = ["autoremove", "-y"]
       }
     }
   }


### PR DESCRIPTION
This commit modifies all garbage collection jobs to run daily rather than hourly. It
also changes the ubuntu packages/distribution job to provide the `-y` flag which was
preventing a successful run. Without this flag a prompt is created which causes the job
to fail.

Signed-off-by: David Bond <davidsbond93@gmail.com>