### PR TITLE
Add reschedule stanzas for ubuntu upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ GitHub action log.
 
 ## Upgrades
 
-Keeping Nomad & Ubuntu up-to-date is done by leveraging Nomad's period jobs & the [raw_exec](https://www.nomadproject.io/docs/drivers/raw_exec)
+Keeping Nomad & Ubuntu up-to-date is done by leveraging Nomad's periodic jobs & the [raw_exec](https://www.nomadproject.io/docs/drivers/raw_exec)
 driver. On a daily basis [this job](terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad) is ran which will keep Ubuntu's packages
 and distribution up-to-date.

--- a/terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad
+++ b/terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad
@@ -9,6 +9,14 @@ job "ubuntu-upgrade" {
   }
 
   group "distribution" {
+    reschedule {
+      attempts       = 5
+      interval       = "2m"
+      delay          = "10s"
+      max_delay      = "30s"
+      delay_function = "exponential"
+    }
+
     task "dist-upgrade" {
       driver = "raw_exec"
 
@@ -20,6 +28,14 @@ job "ubuntu-upgrade" {
   }
 
   group "packages" {
+    reschedule {
+      attempts       = 5
+      interval       = "2m"
+      delay          = "10s"
+      max_delay      = "30s"
+      delay_function = "exponential"
+    }
+
     task "update" {
       driver = "raw_exec"
 


### PR DESCRIPTION
Because we're using apt-get, the job may sometimes fail due to waiting for
the apt lock to clear across the dist-upgrade and normal update/upgrade/autoremove
flow. Using a reschedule allows nomad to rerun things in an exponential manner to
ensure everything runs to completion.

Signed-off-by: David Bond <davidsbond93@gmail.com>