### PR TITLE
Switch to script for ubuntu upgrades

### DIFF
--- a/scripts/upgrade-ubuntu.sh
+++ b/scripts/upgrade-ubuntu.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+apt-get update -y
+apt-get upgrade -y
+apt-get dist-upgrade -y
+apt-get autoremove -y
+apt-get clean -y

--- a/terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad
+++ b/terraform/nomad/jobs/maintenance/ubuntu-upgrade.nomad
@@ -8,68 +8,19 @@ job "ubuntu-upgrade" {
     prohibit_overlap = true
   }
 
-  group "distribution" {
-    reschedule {
-      attempts       = 5
-      interval       = "2m"
-      delay          = "10s"
-      max_delay      = "30s"
-      delay_function = "exponential"
-    }
-
-    task "dist-upgrade" {
+  group "ubuntu-upgrade" {
+    task "ubuntu-upgrade" {
       driver = "raw_exec"
 
       config {
-        command = "apt-get"
-        args    = ["dist-upgrade", "-y"]
-      }
-    }
-  }
-
-  group "packages" {
-    reschedule {
-      attempts       = 5
-      interval       = "2m"
-      delay          = "10s"
-      max_delay      = "30s"
-      delay_function = "exponential"
-    }
-
-    task "update" {
-      driver = "raw_exec"
-
-      lifecycle {
-        hook    = "prestart"
-        sidecar = false
+        command = "./upgrade-ubuntu.sh"
       }
 
-      config {
-        command = "apt-get"
-        args    = ["update"]
-      }
-    }
-
-    task "upgrade" {
-      driver = "raw_exec"
-
-      config {
-        command = "apt-get"
-        args    = ["upgrade", "-y"]
-      }
-    }
-
-    task "autoremove" {
-      driver = "raw_exec"
-
-      lifecycle {
-        hook    = "poststop"
-        sidecar = false
-      }
-
-      config {
-        command = "apt-get"
-        args    = ["autoremove", "-y"]
+      artifact {
+        source = "https://raw.githubusercontent.com/davidsbond/homad/master/scripts/upgrade-ubuntu.sh"
+        options {
+          checksum = "sha256:5764395f1c9c3443f9268debf3455136138d2c99e64dbc5655e0ef033d8f3105"
+        }
       }
     }
   }


### PR DESCRIPTION
This commit modifies the ubuntu upgrade job to use a script from this repository
rather than doing all the complexities of scheduling, lifecycle etc. The reason
for switching to this is that I also wanted to perform an `apt-get clean` but couldn't
find a nice way to fit it all in with the lifecycle.

This should also resolve the issues with apt locking as now there's a single task that
performs all the steps one after the other via a script.

Signed-off-by: David Bond <davidsbond93@gmail.com>