### PR TITLE
Validate nomad jobs with connection to the agent

### DIFF
--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -23,5 +23,12 @@ jobs:
           sudo apt-get update 
           sudo apt-get install nomad
 
+      - name: Connect to Tailnet
+        uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
+
       - name: Validate Nomad jobs
+        env:
+          NOMAD_ADDR: https://homelab.dsb.dev
         run: make nomad-validate

--- a/scripts/upgrade-ubuntu.sh
+++ b/scripts/upgrade-ubuntu.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This script is used on Nomad clients/servers to keep the underlying OS and its packages up-to-date. This script
+# should be ran on a schedule by Nomad itself.
 
 set -e
 

--- a/scripts/validate-jobs.sh
+++ b/scripts/validate-jobs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This script is used to validate all Nomad jobs stored within this repository. When available, the NOMAD_ADDR
+# environment variable should be set to allow validation of driver configuration. Driver configuration is only
+# available if the Nomad agent is also available.
 
 set -e
 

--- a/terraform/nomad/jobs/storage/postgres.nomad
+++ b/terraform/nomad/jobs/storage/postgres.nomad
@@ -64,8 +64,7 @@ job "postgres" {
       }
 
       resources {
-        memory     = 1024
-        memory_max = 2048
+        memory = 1024
       }
 
       template {


### PR DESCRIPTION
This commit modifies the nomad job validation step to connect to Tailscale and
set the `NOMAD_ADDR` environment variable so that we get full job validation
for the driver configuration.

Signed-off-by: David Bond <davidsbond93@gmail.com>