### PR TITLE
Create backup job for postgres instance

### DIFF
--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# This script is used to write the contents of a postgres database to blob storage for backups.
+
+set -e
+
+DATABASES=$(psql -t -c "SELECT datname FROM pg_database WHERE datname NOT IN ('template0', 'template1', 'postgres')")
+
+mc alias set minio https://api.minio.homelab.dsb.dev "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+
+for DATABASE in $DATABASES; do
+  BUCKET_PATH=minio/postgres-backups/"$DATABASE".sql.gz
+  pg_dump --host postgres.homelab.dsb.dev "$DATABASE" | gzip | mc pipe "$BUCKET_PATH"
+done
+
+

--- a/terraform/minio/buckets.tf
+++ b/terraform/minio/buckets.tf
@@ -1,3 +1,3 @@
-resource "minio_s3_bucket" "default" {
-  bucket = "default"
+resource "minio_s3_bucket" "postgres_backups" {
+  bucket = "postgres-backups"
 }

--- a/terraform/nomad/jobs/maintenance/postgres-backup.nomad
+++ b/terraform/nomad/jobs/maintenance/postgres-backup.nomad
@@ -1,0 +1,56 @@
+job "postgres-backup" {
+  datacenters = ["homad"]
+  type        = "sysbatch"
+  region      = "global"
+
+  periodic {
+    cron             = "@hourly"
+    prohibit_overlap = true
+  }
+
+  group "postgres-backup" {
+    task "backup" {
+      driver = "raw_exec"
+
+      config {
+        command = "./backup-database.sh"
+      }
+
+      vault {
+        policies      = ["minio-reader", "postgres-reader"]
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
+      }
+
+      template {
+        destination = "secrets/minio.env"
+        env         = true
+        data        = <<EOT
+{{- with secret "minio/data/root" }}
+MINI0_ACCESS_KEY={{.Data.data.user}}
+MINIO_SECRET_KEY={{.Data.data.password}} 
+{{ end }}
+EOT
+      }
+
+      template {
+        destination = "secrets/postgres.env"
+        env         = true
+        data        = <<EOT
+{{- with secret "postgres/data/root" }}
+PGUSER={{.Data.data.user}}
+PGPASSWORD={{.Data.data.password}}
+PGHOST=postgres.homelab.dsb.dev
+{{ end }}
+EOT
+      }
+
+      artifact {
+        source = "https://raw.githubusercontent.com/davidsbond/homad/master/scripts/backup-database.sh"
+        options {
+          checksum = "sha256:4b2a2ea71906c6b25977f9670af63712fd89792775af392e2b52b6e09b9355fa"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit contains an hourly job that will backup all non-system databases within
the postgres instance using `pg_dump` and write the gzipped contents to a bucket
in minio.

The job is not currently terraformed for initial testing.

Signed-off-by: David Bond <davidsbond93@gmail.com>