### PR TITLE
Add postgres-backup job to terraform state

### DIFF
--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -53,3 +53,7 @@ resource "nomad_job" "docker_gc" {
 resource "nomad_job" "journalctl_gc" {
   jobspec = file("${path.module}/jobs/maintenance/journalctl-gc.nomad")
 }
+
+resource "nomad_job" "postgres_backup" {
+  jobspec = file("${path.module}/jobs/maintenance/postgres-backup.nomad")
+}

--- a/terraform/nomad/jobs/maintenance/postgres-backup.nomad
+++ b/terraform/nomad/jobs/maintenance/postgres-backup.nomad
@@ -1,6 +1,6 @@
 job "postgres-backup" {
   datacenters = ["homad"]
-  type        = "sysbatch"
+  type        = "batch"
   region      = "global"
 
   periodic {
@@ -27,7 +27,7 @@ job "postgres-backup" {
         env         = true
         data        = <<EOT
 {{- with secret "minio/data/root" }}
-MINI0_ACCESS_KEY={{.Data.data.user}}
+MINIO_ACCESS_KEY={{.Data.data.user}}
 MINIO_SECRET_KEY={{.Data.data.password}} 
 {{ end }}
 EOT


### PR DESCRIPTION
This commit adds the postgres backup job to be included in the terraform state. It
also corrects a typo in an environment variable in the job specification.

Signed-off-by: David Bond <davidsbond93@gmail.com>