### PR TITLE
Remove hardcoded hosts in backup scripts

### DIFF
--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -5,11 +5,9 @@ set -e
 
 DATABASES=$(psql -t -c "SELECT datname FROM pg_database WHERE datname NOT IN ('template0', 'template1', 'postgres')")
 
-mc alias set minio https://api.minio.homelab.dsb.dev "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+mc alias set minio "$MINIO_HOST" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
 
 for DATABASE in $DATABASES; do
   BUCKET_PATH=minio/postgres-backups/"$DATABASE".sql.gz
-  pg_dump --host postgres.homelab.dsb.dev "$DATABASE" | gzip | mc pipe "$BUCKET_PATH"
+  pg_dump "$DATABASE" | gzip | mc pipe "$BUCKET_PATH"
 done
-
-

--- a/terraform/nomad/jobs/maintenance/postgres-backup.nomad
+++ b/terraform/nomad/jobs/maintenance/postgres-backup.nomad
@@ -28,7 +28,8 @@ job "postgres-backup" {
         data        = <<EOT
 {{- with secret "minio/data/root" }}
 MINIO_ACCESS_KEY={{.Data.data.user}}
-MINIO_SECRET_KEY={{.Data.data.password}} 
+MINIO_SECRET_KEY={{.Data.data.password}}
+MINIO_HOST=https://api.minio.homelab.dsb.dev
 {{ end }}
 EOT
       }
@@ -48,7 +49,7 @@ EOT
       artifact {
         source = "https://raw.githubusercontent.com/davidsbond/homad/master/scripts/backup-database.sh"
         options {
-          checksum = "sha256:4b2a2ea71906c6b25977f9670af63712fd89792775af392e2b52b6e09b9355fa"
+          checksum = "sha256:93959e944e41346f2e13eac2452170e05a92f4ba916060b1d9e84a2070fc26f4"
         }
       }
     }


### PR DESCRIPTION
This commit removes the hardcoded hosts from the backup script for both
minio and postgres, getting them exclusively from templated environment
variables.

Signed-off-by: David Bond <davidsbond93@gmail.com>