### PR TITLE
Get grafana working with persistent storage

### DIFF
--- a/terraform/nomad/jobs/monitoring/grafana.nomad
+++ b/terraform/nomad/jobs/monitoring/grafana.nomad
@@ -10,15 +10,17 @@ job "grafana" {
       }
     }
 
-    ephemeral_disk {
-      migrate = true
-      size    = 100
-      sticky  = true
+    volume "grafana" {
+      type            = "csi"
+      source          = "grafana"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
     }
 
     task "grafana" {
       driver = "docker"
-      user   = "472"
+      user   = "root"
 
       vault {
         policies      = ["grafana-reader"]
@@ -29,6 +31,11 @@ job "grafana" {
       config {
         image = "grafana/grafana:9.0.2"
         ports = ["grafana"]
+      }
+
+      volume_mount {
+        volume      = "grafana"
+        destination = "/var/lib/grafana"
       }
 
       logs {

--- a/terraform/nomad/volumes.tf
+++ b/terraform/nomad/volumes.tf
@@ -69,3 +69,21 @@ resource "nomad_external_volume" "minio" {
     prevent_destroy = false
   }
 }
+
+resource "nomad_external_volume" "grafana" {
+  type         = "csi"
+  plugin_id    = "nfs"
+  volume_id    = "grafana"
+  name         = "grafana"
+  capacity_min = "10M"
+  capacity_max = "1Gi"
+
+  capability {
+    access_mode     = "multi-node-multi-writer"
+    attachment_mode = "file-system"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}


### PR DESCRIPTION
This commit modifies the grafana job to use the root user and mount a CSI
volume at /var/lib/grafana. After trying a multitude of things and googling
a lot the only way I could avoid FS permissions was to use the root user. This
probably isn't the best way but it does work.

Signed-off-by: David Bond <davidsbond93@gmail.com>