### PR TITLE
Add prometheus deployment

### DIFF
--- a/terraform/consul/files/prometheus/prometheus.yml
+++ b/terraform/consul/files/prometheus/prometheus.yml
@@ -1,0 +1,34 @@
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  # Job that polls the nomad prometheus metric endpoints
+  - job_name: nomad-metrics
+    consul_sd_configs:
+      - server: https://consul.homelab.dsb.dev
+        services: ['nomad-client', 'nomad']
+    relabel_configs:
+      - source_labels: ['__meta_consul_tags']
+        regex: '(.*)http(.*)'
+        action: keep
+    scrape_interval: 5s
+    metrics_path: /v1/metrics
+    params:
+      format: ['prometheus']
+
+  # Job that polls the traefik instance's metric endpoints
+  - job_name: traefik-metrics
+    consul_sd_configs:
+      - server: https://consul.homelab.dsb.dev
+        services: ['traefik-metrics']
+    scrape_interval: 5s
+    metrics_path: /metrics
+
+  # Job that polls the minio instance's metric endpoint
+  - job_name: minio-metrics
+    consul_sd_configs:
+      - server: https://consul.homelab.dsb.dev
+        services: ['minio-api']
+    scrape_interval: 5s
+    metrics_path: /minio/v2/metrics/cluster

--- a/terraform/consul/files/traefik/traefik.yaml
+++ b/terraform/consul/files/traefik/traefik.yaml
@@ -29,8 +29,17 @@ entryPoints:
   postgres:
     address: :5432
 
+  metrics:
+    address: :8083
+
 ping:
   entryPoint: ping
+
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addEntryPointsLabels: true
+    addServicesLabels: true
 
 certificatesResolvers:
   cloudflare:

--- a/terraform/consul/minio.tf
+++ b/terraform/consul/minio.tf
@@ -6,5 +6,6 @@ resource "consul_key_prefix" "minio" {
     MINIO_BROWSER_REDIRECT_URL = "https://ui.minio.homelab.dsb.dev"
     MINIO_SITE_REGION          = "homelab"
     MINIO_SITE_NAME            = "homelab"
+    MINIO_PROMETHEUS_AUTH_TYPE = "public"
   }
 }

--- a/terraform/consul/prometheus.tf
+++ b/terraform/consul/prometheus.tf
@@ -1,0 +1,6 @@
+resource "consul_key_prefix" "prometheus" {
+  path_prefix = "homad/prometheus/"
+  subkeys = {
+    "prometheus.yml" = file("${path.module}/files/prometheus/prometheus.yml"),
+  }
+}

--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -57,3 +57,7 @@ resource "nomad_job" "journalctl_gc" {
 resource "nomad_job" "postgres_backup" {
   jobspec = file("${path.module}/jobs/maintenance/postgres-backup.nomad")
 }
+
+resource "nomad_job" "prometheus" {
+  jobspec = file("${path.module}/jobs/monitoring/prometheus.nomad")
+}

--- a/terraform/nomad/jobs/monitoring/prometheus.nomad
+++ b/terraform/nomad/jobs/monitoring/prometheus.nomad
@@ -1,0 +1,69 @@
+job "prometheus" {
+  region      = "global"
+  datacenters = ["homad"]
+  type        = "service"
+
+  group "prometheus" {
+    count = 1
+
+    network {
+      port "prometheus" {
+        static = 9090
+      }
+    }
+
+    volume "prometheus" {
+      type            = "csi"
+      source          = "prometheus"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    service {
+      name = "prometheus"
+      port = "prometheus"
+      task = "prometheus"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.prometheus.rule=Host(`prometheus.homelab.dsb.dev`)",
+        "traefik.http.routers.prometheus.entrypoints=https",
+        "traefik.http.routers.prometheus.tls.certresolver=cloudflare"
+      ]
+
+      check {
+        name     = "prometheus"
+        type     = "http"
+        path     = "/-/healthy"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "prometheus" {
+      driver = "docker"
+      user   = "root"
+
+      config {
+        image = "prom/prometheus:v2.37.0"
+        ports = ["prometheus"]
+        volumes = [
+          "local/prometheus.yml:/etc/prometheus/prometheus.yml",
+        ]
+      }
+
+      volume_mount {
+        volume      = "prometheus"
+        destination = "/prometheus"
+      }
+
+      template {
+        destination = "local/prometheus.yml"
+        data        = <<EOT
+{{- key "homad/prometheus/prometheus.yml" }}
+EOT
+      }
+    }
+  }
+}

--- a/terraform/nomad/jobs/networking/traefik.nomad
+++ b/terraform/nomad/jobs/networking/traefik.nomad
@@ -39,6 +39,10 @@ job "traefik" {
       port "traefik" {
         static = 8080
       }
+
+      port "metrics" {
+        static = 8083
+      }
     }
 
     ephemeral_disk {
@@ -66,6 +70,11 @@ job "traefik" {
         timeout  = "30s"
         port     = "ping"
       }
+    }
+
+    service {
+      name = "traefik-metrics"
+      port = "metrics"
     }
 
     task "traefik" {

--- a/terraform/nomad/volumes.tf
+++ b/terraform/nomad/volumes.tf
@@ -87,3 +87,21 @@ resource "nomad_external_volume" "grafana" {
     prevent_destroy = false
   }
 }
+
+resource "nomad_external_volume" "prometheus" {
+  type         = "csi"
+  plugin_id    = "nfs"
+  volume_id    = "prometheus"
+  name         = "prometheus"
+  capacity_min = "10M"
+  capacity_max = "10Gi"
+
+  capability {
+    access_mode     = "multi-node-multi-writer"
+    attachment_mode = "file-system"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}


### PR DESCRIPTION
This commit deployes prometheus to the nomad cluster with scrape configurations for
nomad clients/servers, minio & traefik. The minio and traefik jobs have been updated
to allow prometheus to get metrics from them.

Signed-off-by: David Bond <davidsbond93@gmail.com>