### PR TITLE
Add prometheus-node-exporter

### DIFF
--- a/terraform/consul/files/prometheus/prometheus.yml
+++ b/terraform/consul/files/prometheus/prometheus.yml
@@ -32,3 +32,11 @@ scrape_configs:
         services: ['minio-api']
     scrape_interval: 5s
     metrics_path: /minio/v2/metrics/cluster
+
+  # Job that polls the node-exporter instance's metric endpoint
+  - job_name: node-metrics
+    consul_sd_configs:
+      - server: https://consul.homelab.dsb.dev
+        services: ['node-exporter']
+    scrape_interval: 5s
+    metrics_path: /metrics

--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -61,3 +61,7 @@ resource "nomad_job" "postgres_backup" {
 resource "nomad_job" "prometheus" {
   jobspec = file("${path.module}/jobs/monitoring/prometheus.nomad")
 }
+
+resource "nomad_job" "prometheus_node_exporter" {
+  jobspec = file("${path.module}/jobs/monitoring/prometheus-node-exporter.nomad")
+}

--- a/terraform/nomad/jobs/monitoring/prometheus-node-exporter.nomad
+++ b/terraform/nomad/jobs/monitoring/prometheus-node-exporter.nomad
@@ -1,0 +1,38 @@
+job "prometheus-node-exporter" {
+  region      = "global"
+  datacenters = ["homad"]
+  type        = "system"
+
+  group "node-exporter" {
+    count = 1
+
+    network {
+      port "metrics" {
+        to = 9100
+      }
+    }
+
+    service {
+      name = "node-exporter"
+      port = "metrics"
+      task = "node-exporter"
+    }
+
+    task "node-exporter" {
+      driver = "docker"
+
+      config {
+        image = "prom/node-exporter:v1.3.1"
+        ports = ["metrics"]
+        args = [
+          "--path.procfs=/host/proc",
+          "--path.sysfs=/host/sys"
+        ]
+        volumes = [
+          "/proc:/host/proc:ro",
+          "/sys:/host/sys:ro"
+        ]
+      }
+    }
+  }
+}

--- a/terraform/nomad/jobs/monitoring/prometheus.nomad
+++ b/terraform/nomad/jobs/monitoring/prometheus.nomad
@@ -8,7 +8,7 @@ job "prometheus" {
 
     network {
       port "prometheus" {
-        static = 9090
+        to = 9090
       }
     }
 


### PR DESCRIPTION
This commit adds the prometheus-node-exporter to the cluster that will export metrics
about the linux host. The prometheus configuration has been updated to scrape it.

Signed-off-by: David Bond <davidsbond93@gmail.com>