### PR TITLE
Deploy prometheus postgres exporter

### DIFF
--- a/terraform/consul/files/prometheus/prometheus.yml
+++ b/terraform/consul/files/prometheus/prometheus.yml
@@ -40,3 +40,11 @@ scrape_configs:
         services: ['node-exporter']
     scrape_interval: 5s
     metrics_path: /metrics
+
+  # Job that polls the exporter-postgres instance's metric endpoint
+  - job_name: postgres-metrics
+    consul_sd_configs:
+      - server: https://consul.homelab.dsb.dev
+        services: ['prometheus-exporter-postgres']
+    scrape_interval: 5s
+    metrics_path: /metrics

--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -65,3 +65,7 @@ resource "nomad_job" "prometheus" {
 resource "nomad_job" "prometheus_node_exporter" {
   jobspec = file("${path.module}/jobs/monitoring/prometheus-node-exporter.nomad")
 }
+
+resource "nomad_job" "prometheus_exporter_postgres" {
+  jobspec = file("${path.module}/jobs/monitoring/prometheus-exporter-postgres.nomad")
+}

--- a/terraform/nomad/jobs/monitoring/prometheus-exporter-postgres.nomad
+++ b/terraform/nomad/jobs/monitoring/prometheus-exporter-postgres.nomad
@@ -1,0 +1,49 @@
+job "prometheus-exporter-postgres" {
+  region      = "global"
+  datacenters = ["homad"]
+  type        = "service"
+
+  group "prometheus-exporter-postgres" {
+    count = 1
+
+    network {
+      port "metrics" {
+        to = 9187
+      }
+    }
+
+    service {
+      name = "prometheus-exporter-postgres"
+      port = "metrics"
+      task = "prometheus-exporter-postgres"
+    }
+
+    task "prometheus-exporter-postgres" {
+      driver = "docker"
+
+      vault {
+        policies      = ["postgres-reader"]
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
+      }
+
+      config {
+        image = "prometheuscommunity/postgres-exporter:v0.11.0"
+        ports = ["metrics"]
+        args = [
+          "--auto-discover-databases"
+        ]
+      }
+
+      template {
+        destination = "secrets/postgres.env"
+        env         = true
+        data        = <<EOT
+{{- with secret "postgres/data/root" }}
+DATA_SOURCE_NAME=postgresql://{{.Data.data.user}}:{{.Data.data.password}}@postgres.homelab.dsb.dev:5432/postgres?sslmode=disable
+{{ end }}
+EOT
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the postgres exporter for prometheus that will expose metrics
about the postgres instance running in the nomad cluster.

Signed-off-by: David Bond <davidsbond93@gmail.com>