### PR TITLE
Ensure traefik runs on all nodes in cluster

### DIFF
--- a/terraform/nomad/jobs/networking/traefik.nomad
+++ b/terraform/nomad/jobs/networking/traefik.nomad
@@ -4,7 +4,7 @@ job "traefik" {
   type        = "service"
 
   group "traefik" {
-    count = 3
+    count = 4
 
     constraint {
       operator = "distinct_hosts"

--- a/terraform/tailscale/output.tf
+++ b/terraform/tailscale/output.tf
@@ -1,9 +1,6 @@
-# homad-0 is the server node, so it won't be serving any traffic, we want to get all tailscale devices whose
-# names are prefixed with "homad-", filter out "homad-0" and return the first address for each node.
 output "homelab_clients" {
   value = [
     for client in data.tailscale_devices.nomad_clients.devices : element(client.addresses, 0)
-    if client.name != "homad-0.davidsbond93.gmail.com"
   ]
 }
 


### PR DESCRIPTION
This commit modifies the DNS records to include the nomad server which now
runs as both a server and client. This is not technically recommended but for
my use case isn't particularly worrying.

It allows hitting the endpoints of any of the nomad clients and the filtering
for the 0th node has been removed.

Signed-off-by: David Bond <davidsbond93@gmail.com>