### PR TITLE
Add backup jobs for nomad configuration

### DIFF
--- a/scripts/backup-nomad-config.sh
+++ b/scripts/backup-nomad-config.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# This script is used to write the local nomad configuration to blob storage for backups.
+
+set -e
+
+mc alias set minio "$MINIO_HOST" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+
+BUCKET_PATH=minio/nomad-backups/"$(hostname)".hcl.gz
+gzip /etc/nomad.d/nomad.hcl | mc pipe "$BUCKET_PATH"

--- a/terraform/minio/buckets.tf
+++ b/terraform/minio/buckets.tf
@@ -1,3 +1,7 @@
 resource "minio_s3_bucket" "postgres_backups" {
   bucket = "postgres-backups"
 }
+
+resource "minio_s3_bucket" "nomad_backups" {
+  bucket = "nomad-backups"
+}

--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -69,3 +69,7 @@ resource "nomad_job" "prometheus_node_exporter" {
 resource "nomad_job" "prometheus_exporter_postgres" {
   jobspec = file("${path.module}/jobs/monitoring/prometheus-exporter-postgres.nomad")
 }
+
+resource "nomad_job" "nomad_config_backup" {
+  jobspec = file("${path.module}/jobs/maintenance/nomad-config-backup.nomad")
+}

--- a/terraform/nomad/jobs/maintenance/nomad-config-backup.nomad
+++ b/terraform/nomad/jobs/maintenance/nomad-config-backup.nomad
@@ -1,0 +1,45 @@
+job "nomad-config-backup" {
+  datacenters = ["homad"]
+  type        = "sysbatch"
+  region      = "global"
+
+  periodic {
+    cron             = "@daily"
+    prohibit_overlap = true
+  }
+
+  group "nomad-config-backup" {
+    task "nomad-config-backup" {
+      driver = "raw_exec"
+
+      config {
+        command = "./backup-nomad-config.sh"
+      }
+
+      vault {
+        policies      = ["minio-reader"]
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
+      }
+
+      template {
+        destination = "secrets/minio.env"
+        env         = true
+        data        = <<EOT
+{{- with secret "minio/data/root" }}
+MINIO_ACCESS_KEY={{.Data.data.user}}
+MINIO_SECRET_KEY={{.Data.data.password}}
+MINIO_HOST=https://api.minio.homelab.dsb.dev
+{{ end }}
+EOT
+      }
+
+      artifact {
+        source = "https://raw.githubusercontent.com/davidsbond/homad/master/scripts/backup-nomad-config.sh"
+        options {
+          checksum = "sha256:93caf164c2e7819de9497a4eaca068da818a09ad01eb07214729487eeb00c5cd"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a sysbatch job that will backup the configuration for all nomad
clients/servers in the cluster and write them to blob storage.

Signed-off-by: David Bond <davidsbond93@gmail.com>