### PR TITLE
Correct invalid use of gzip in backup script

### DIFF
--- a/scripts/backup-nomad-config.sh
+++ b/scripts/backup-nomad-config.sh
@@ -6,4 +6,4 @@ set -e
 mc alias set minio "$MINIO_HOST" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
 
 BUCKET_PATH=minio/nomad-backups/"$(hostname)".hcl.gz
-gzip /etc/nomad.d/nomad.hcl | mc pipe "$BUCKET_PATH"
+gzip -c /etc/nomad.d/nomad.hcl | mc pipe "$BUCKET_PATH"

--- a/terraform/consul/files/prometheus/prometheus.yml
+++ b/terraform/consul/files/prometheus/prometheus.yml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval:     5s
-  evaluation_interval: 5s
+  scrape_interval:     1m
+  evaluation_interval: 1m
 
 scrape_configs:
   # Job that polls the nomad prometheus metric endpoints
@@ -12,7 +12,6 @@ scrape_configs:
       - source_labels: ['__meta_consul_tags']
         regex: '(.*)http(.*)'
         action: keep
-    scrape_interval: 5s
     metrics_path: /v1/metrics
     params:
       format: ['prometheus']
@@ -22,7 +21,6 @@ scrape_configs:
     consul_sd_configs:
       - server: https://consul.homelab.dsb.dev
         services: ['traefik-metrics']
-    scrape_interval: 5s
     metrics_path: /metrics
 
   # Job that polls the minio instance's metric endpoint
@@ -30,7 +28,6 @@ scrape_configs:
     consul_sd_configs:
       - server: https://consul.homelab.dsb.dev
         services: ['minio-api']
-    scrape_interval: 5s
     metrics_path: /minio/v2/metrics/cluster
 
   # Job that polls the node-exporter instance's metric endpoint
@@ -38,7 +35,6 @@ scrape_configs:
     consul_sd_configs:
       - server: https://consul.homelab.dsb.dev
         services: ['node-exporter']
-    scrape_interval: 5s
     metrics_path: /metrics
 
   # Job that polls the exporter-postgres instance's metric endpoint
@@ -46,5 +42,4 @@ scrape_configs:
     consul_sd_configs:
       - server: https://consul.homelab.dsb.dev
         services: ['prometheus-exporter-postgres']
-    scrape_interval: 5s
     metrics_path: /metrics

--- a/terraform/nomad/jobs/maintenance/nomad-config-backup.nomad
+++ b/terraform/nomad/jobs/maintenance/nomad-config-backup.nomad
@@ -37,7 +37,7 @@ EOT
       artifact {
         source = "https://raw.githubusercontent.com/davidsbond/homad/master/scripts/backup-nomad-config.sh"
         options {
-          checksum = "sha256:93caf164c2e7819de9497a4eaca068da818a09ad01eb07214729487eeb00c5cd"
+          checksum = "sha256:d1375ced1fc0f6058e5377c00054a965aabd9710f2ba1797ac9db23759d19494"
         }
       }
     }


### PR DESCRIPTION
This commit modifies the nomad configuration job to force the gzip
output to the terminal instead of gzipping in-place. Just had to go
un-gzip all my configurations.

Signed-off-by: David Bond <davidsbond93@gmail.com>