### PR TITLE
Give minio more memory

### DIFF
--- a/terraform/nomad/jobs/storage/minio.nomad
+++ b/terraform/nomad/jobs/storage/minio.nomad
@@ -83,6 +83,10 @@ job "minio" {
         change_signal = "SIGUSR1"
       }
 
+      resources {
+        memory = 1024
+      }
+
       logs {
         max_files = 1
       }


### PR DESCRIPTION
The minio instance seems to regularly get OOMKilled when using the default
memory assigned by nomad. This commit grants the minio instance up to 1Gi
of memory.

Signed-off-by: David Bond <davidsbond93@gmail.com>