### PR TITLE
Get terraform plan contents as a comment on the PR

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - '**.tf'
       - '**.nomad'
+      - '.github/workflows/terraform.yml'
   pull_request:
     paths:
       - '**.tf'
       - '**.nomad'
+      - '.github/workflows/terraform.yml'
 
 jobs:
   format:
@@ -56,7 +58,21 @@ jobs:
         run: make init
 
       - name: Terraform Plan
+        id: plan
         run: make plan
+
+      - name: Add plan output to PR
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            <details>
+              <summary>
+                Output of plan:
+              </summary>
+              <pre>${{steps.plan.outputs.stdout}}</pre>
+            </details>
+          GITHUB_TOKEN: ${{ github.token }}
 
   apply:
     concurrency: terraform

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ init-upgrade:
 	cd terraform && terraform init -upgrade
 
 plan:
-	cd terraform && terraform plan -var-file=.tfvars -out .plan
+	cd terraform && terraform plan -no-color -var-file=.tfvars -out .plan
 
 apply:
 	cd terraform && terraform apply .plan


### PR DESCRIPTION
This commit attempts to add a step to the plan workflow that will leave
a comment with the contents of `terraform plan` on it.

Signed-off-by: David Bond <davidsbond93@gmail.com>