### PR TITLE
Use tags to release binaries individually

### DIFF
--- a/.github/workflows/apps-speed-dial.yml
+++ b/.github/workflows/apps-speed-dial.yml
@@ -1,8 +1,8 @@
 name: speed-dial
 on:
   push:
-    branches:
-      - master
+    tags:
+      - "v*"
     paths:
       - 'apps/speed-dial/**'
       - 'apps/go.mod'
@@ -35,7 +35,7 @@ jobs:
 
   release:
     runs-on: ubuntu-22.04
-    if: github.ref == 'refs/heads/master'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - vet
     steps:

--- a/apps/speed-dial/.goreleaser.yml
+++ b/apps/speed-dial/.goreleaser.yml
@@ -1,3 +1,6 @@
+snapshot:
+  name_template: "{{ .Commit }}"
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -5,7 +8,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      - "-s -w -X main.version={{.Version}} -X main.commit={{ .Commit }}"
     goos:
       - linux
     goarch:
@@ -18,6 +21,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-amd64"
       - "ghcr.io/davidsbond/homad-speed-dial:latest-amd64"
     dockerfile: Dockerfile
     use: buildx
@@ -29,6 +33,7 @@ dockers:
     goos: linux
     goarch: arm64
     image_templates:
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-arm64"
       - "ghcr.io/davidsbond/homad-speed-dial:latest-arm64"
     dockerfile: Dockerfile
     use: buildx
@@ -41,6 +46,10 @@ docker_manifests:
     image_templates:
       - "ghcr.io/davidsbond/homad-speed-dial:latest-amd64"
       - "ghcr.io/davidsbond/homad-speed-dial:latest-arm64"
+  - name_template: "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-amd64"
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-arm64"
 
 release:
   disable: true


### PR DESCRIPTION
This commit modifies the goreleaser configuration to use tags appropriately.
When a tag is pushed, only the applications that have changed should have
their releases pushed.

Signed-off-by: David Bond <davidsbond93@gmail.com>