### PR TITLE
Use commits instead of git tags for images

### DIFF
--- a/.github/workflows/apps-speed-dial.yml
+++ b/.github/workflows/apps-speed-dial.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - master
     paths:
       - 'apps/speed-dial/**'
       - 'apps/go.mod'
@@ -35,7 +37,7 @@ jobs:
 
   release:
     runs-on: ubuntu-22.04
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - vet
     steps:

--- a/apps/speed-dial/.goreleaser.yml
+++ b/apps/speed-dial/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X main.commit={{ .Commit }}"
+      - "-s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}"
     goos:
       - linux
     goarch:
@@ -21,7 +21,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-amd64"
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Commit }}-amd64"
       - "ghcr.io/davidsbond/homad-speed-dial:latest-amd64"
     dockerfile: Dockerfile
     use: buildx
@@ -33,7 +33,7 @@ dockers:
     goos: linux
     goarch: arm64
     image_templates:
-      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-arm64"
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Commit }}-arm64"
       - "ghcr.io/davidsbond/homad-speed-dial:latest-arm64"
     dockerfile: Dockerfile
     use: buildx
@@ -46,10 +46,10 @@ docker_manifests:
     image_templates:
       - "ghcr.io/davidsbond/homad-speed-dial:latest-amd64"
       - "ghcr.io/davidsbond/homad-speed-dial:latest-arm64"
-  - name_template: "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}"
+  - name_template: "ghcr.io/davidsbond/homad-speed-dial:{{ .Commit }}"
     image_templates:
-      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-amd64"
-      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Tag }}-arm64"
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Commit }}-amd64"
+      - "ghcr.io/davidsbond/homad-speed-dial:{{ .Commit }}-arm64"
 
 release:
   disable: true


### PR DESCRIPTION
This commit modifies the goreleaser workflow to use commits for image tag names
rather than git tags. If we have multiple apps in here we don't want the versioning
to be weird where the first version of a new app's image is something like 0.5.0 etc, so
from now on all images just use the commit sha and we can make tag names anything we
want to trigger the workflow.

The vet job should also run on pushes to master now.

Signed-off-by: David Bond <davidsbond93@gmail.com>