### PR TITLE
Enable dependabot for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: gomod
+    directory: /apps
+    schedule:
+      interval: daily


### PR DESCRIPTION
This commit enables dependabot pull requests for go module
upgrades.

Signed-off-by: David Bond <davidsbond93@gmail.com>