### PR TITLE
Deploy pihole prometheus exporter

### DIFF
--- a/terraform/consul/files/prometheus/prometheus.yml
+++ b/terraform/consul/files/prometheus/prometheus.yml
@@ -43,3 +43,10 @@ scrape_configs:
       - server: https://consul.homelab.dsb.dev
         services: ['prometheus-exporter-postgres']
     metrics_path: /metrics
+
+  # Job that polls the exporter-pihole instance's metric endpoint
+  - job_name: pihole-metrics
+    consul_sd_configs:
+      - server: https://consul.homelab.dsb.dev
+        services: ['prometheus-exporter-pihole']
+    metrics_path: /metrics

--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -73,3 +73,7 @@ resource "nomad_job" "prometheus_exporter_postgres" {
 resource "nomad_job" "nomad_config_backup" {
   jobspec = file("${path.module}/jobs/maintenance/nomad-config-backup.nomad")
 }
+
+resource "nomad_job" "prometheus_exporter_pihole" {
+  jobspec = file("${path.module}/jobs/monitoring/prometheus-exporter-pihole.nomad")
+}

--- a/terraform/nomad/jobs/monitoring/prometheus-exporter-pihole.nomad
+++ b/terraform/nomad/jobs/monitoring/prometheus-exporter-pihole.nomad
@@ -1,0 +1,55 @@
+job "prometheus-exporter-pihole" {
+  region      = "global"
+  datacenters = ["homad"]
+  type        = "service"
+
+  group "prometheus-exporter-pihole" {
+    count = 1
+
+    network {
+      port "metrics" {
+        to = 9617
+      }
+    }
+
+    service {
+      name = "prometheus-exporter-pihole"
+      task = "prometheus-exporter-pihole"
+      port = "metrics"
+    }
+
+    task "prometheus-exporter-pihole" {
+      driver = "docker"
+
+      vault {
+        policies      = ["pihole-reader"]
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
+      }
+
+      config {
+        image = "ekofr/pihole-exporter:v0.3.0"
+        ports = ["metrics"]
+      }
+
+      template {
+        destination = "local/pihole.env"
+        env         = true
+        data        = <<EOT
+PIHOLE_HOSTNAME={{- range $i, $instance := service "pihole" }}{{ $instance.Address }}{{ if eq $i 0  }},{{end}}{{ end }}
+PIHOLE_PORT={{- range $i, $instance := service "pihole" }}{{ $instance.Port }}{{ if eq $i 0  }},{{end}}{{ end }}
+PIHOLE_PROTOCOL=http
+EOT
+      }
+      template {
+        destination = "secrets/pihole.env"
+        env         = true
+        data        = <<EOT
+{{- with secret "pihole/data/auth" }}
+PIHOLE_PASSWORD={{.Data.data.password}}
+{{ end }}
+EOT
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a prometheus exporter for pihole configured to poll both
pihole instances running in the cluster.

Signed-off-by: David Bond <davidsbond93@gmail.com>