### PR TITLE
Move everything else into its own namespace

### DIFF
--- a/terraform/nomad/jobs/csi/controller.nomad
+++ b/terraform/nomad/jobs/csi/controller.nomad
@@ -1,6 +1,7 @@
 job "storage-controller" {
   datacenters = ["homad"]
   type        = "service"
+  namespace   = "csi"
 
   group "controller" {
     task "controller" {

--- a/terraform/nomad/jobs/csi/node.nomad
+++ b/terraform/nomad/jobs/csi/node.nomad
@@ -1,6 +1,7 @@
 job "storage-node" {
   datacenters = ["homad"]
   type        = "system"
+  namespace   = "csi"
 
   group "node" {
     task "node" {

--- a/terraform/nomad/jobs/networking/pihole.nomad
+++ b/terraform/nomad/jobs/networking/pihole.nomad
@@ -2,6 +2,7 @@ job "pihole" {
   region      = "global"
   datacenters = ["homad"]
   type        = "service"
+  namespace   = "networking"
 
   group "pihole" {
     count = 2

--- a/terraform/nomad/jobs/networking/traefik.nomad
+++ b/terraform/nomad/jobs/networking/traefik.nomad
@@ -2,6 +2,7 @@ job "traefik" {
   region      = "global"
   datacenters = ["homad"]
   type        = "service"
+  namespace   = "networking"
 
   group "traefik" {
     count = 4

--- a/terraform/nomad/jobs/storage/minio.nomad
+++ b/terraform/nomad/jobs/storage/minio.nomad
@@ -2,6 +2,7 @@ job "minio" {
   datacenters = ["homad"]
   type        = "service"
   region      = "global"
+  namespace   = "storage"
 
   group "minio" {
     network {

--- a/terraform/nomad/jobs/storage/postgres.nomad
+++ b/terraform/nomad/jobs/storage/postgres.nomad
@@ -2,6 +2,7 @@ job "postgres" {
   datacenters = ["homad"]
   type        = "service"
   region      = "global"
+  namespace   = "storage"
 
   group "postgres" {
     network {

--- a/terraform/nomad/namespaces.tf
+++ b/terraform/nomad/namespaces.tf
@@ -27,3 +27,8 @@ resource "nomad_namespace" "security" {
   name        = "security"
   description = "The namespace for jobs that provide security functionality"
 }
+
+resource "nomad_namespace" "csi" {
+  name        = "csi"
+  description = "The namespace for CSI drivers"
+}

--- a/terraform/nomad/volumes.tf
+++ b/terraform/nomad/volumes.tf
@@ -43,6 +43,7 @@ resource "nomad_external_volume" "postgres" {
   name         = "postgres"
   capacity_min = "10M"
   capacity_max = "1Gi"
+  namespace    = "storage"
 
   capability {
     access_mode     = "multi-node-multi-writer"
@@ -61,6 +62,7 @@ resource "nomad_external_volume" "minio" {
   name         = "minio"
   capacity_min = "10M"
   capacity_max = "100Gi"
+  namespace    = "storage"
 
   capability {
     access_mode     = "multi-node-multi-writer"


### PR DESCRIPTION
This commit finishes off the namespacing work, now all the jobs have their own
specific namespaces.

Signed-off-by: David Bond <davidsbond93@gmail.com>