### PR TITLE
Switch to official tailscale terraform provider

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -207,3 +207,25 @@ provider "registry.terraform.io/hashicorp/vault" {
     "zh:f6d39c4d3861ff682969a1fe4b960b7a27eda49c5a9747f20e24c56f3817a4cd",
   ]
 }
+
+provider "registry.terraform.io/tailscale/tailscale" {
+  version     = "0.13.5"
+  constraints = "0.13.5"
+  hashes = [
+    "h1:xNlGd2QJsdjUSx/zYkaY4IZS7p7dmmSrnzmIf2Ou5cM=",
+    "zh:0511b61e75a1ed649288cb428d276751c1e4f34d1de301aafaccea08cea9ee20",
+    "zh:0894bcf4b3f0ffadb3252d70efa3cbcb4f91efc5accd6d1b455e3b08ed09e249",
+    "zh:2930a2828bcb516a5ba9916f35c2538afb5293666e383c9a4dbfbfadbce60e14",
+    "zh:6bdb88e1ae254aa7c240fd1e1c5509bd6d616c4d5e8f8e486d6ba46bcee7620f",
+    "zh:81a5ab33d1ec3ae4d1a7dabbad843f4615b19e0f97bdc402d8195faa7b05b0e9",
+    "zh:9c3d98ac0dfa20fffa9e0f2f19263590e779595689d2e0133de50dd543a86ab4",
+    "zh:bd1982383c0956d555152b77c7a14b0ab4301d123ae43d075b1cb5f1f667452d",
+    "zh:bf7234f3192669f58f06add065bd5174a0309935d65c5e681b679ccd76fc8b11",
+    "zh:bfeda86b5e7654f7a3540fe416ae8432095ffdd7452917117f1dcc3a7a912d92",
+    "zh:c62227c3340c9fb3d97c3c7a086f7f8c3155ff9f3bce54eee7205ab9b70cf74b",
+    "zh:ddc91a61a5f751c358708ddd6369e9f89bc10b1ae08816580bc7d1b0ba323bcd",
+    "zh:e681ebc44854e1ba3e16925e13f4947691bf101e678fdb4b123edf21a698ff33",
+    "zh:fa0a8509820dedb3b57c7cb832110d1f9ee4550c6891662d314bd488d94df5a0",
+    "zh:fb57c329656cec5b2fafe415eaeb2c7a7f182c53854351a901a80ab656a533e9",
+  ]
+}

--- a/terraform/tailscale/provider.tf
+++ b/terraform/tailscale/provider.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     tailscale = {
-      source  = "davidsbond/tailscale"
-      version = "0.12.2"
+      source  = "tailscale/tailscale"
+      version = "0.13.5"
     }
   }
 }


### PR DESCRIPTION
This commit switches from davidsbond/tailscale to the official provider
now at tailscale/tailscale. Since it's the same provider but under a new
namespace there's no additional changes required! Very cool!

Signed-off-by: David Bond <davidsbond93@gmail.com>