### PR TITLE
Add daily job to vacuum postgres

### DIFF
--- a/terraform/nomad/jobs.tf
+++ b/terraform/nomad/jobs.tf
@@ -81,3 +81,7 @@ resource "nomad_job" "prometheus_exporter_pihole" {
 resource "nomad_job" "speed_dial" {
   jobspec = file("${path.module}/jobs/apps/speed-dial.nomad")
 }
+
+resource "nomad_job" "postgres_vacuum" {
+  jobspec = file("${path.module}/jobs/maintenance/postgres-vacuum.nomad")
+}

--- a/terraform/nomad/jobs/maintenance/postgres-vacuum.nomad
+++ b/terraform/nomad/jobs/maintenance/postgres-vacuum.nomad
@@ -1,0 +1,40 @@
+job "postgres-vacuum" {
+  datacenters = ["homad"]
+  type        = "batch"
+  region      = "global"
+  namespace   = "maintenance"
+
+  periodic {
+    cron             = "@daily"
+    prohibit_overlap = true
+  }
+
+  group "postgres-vacuum" {
+    task "vacuum" {
+      driver = "raw_exec"
+
+      config {
+        command = "vacuumdb"
+        args    = ["--all", "--skip-locked", "--full"]
+      }
+
+      vault {
+        policies      = ["postgres-reader"]
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
+      }
+
+      template {
+        destination = "secrets/postgres.env"
+        env         = true
+        data        = <<EOT
+{{- with secret "postgres/data/root" }}
+PGUSER={{.Data.data.user}}
+PGPASSWORD={{.Data.data.password}}
+PGHOST=postgres.homelab.dsb.dev
+{{ end }}
+EOT
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a daily job that performs a full vacuum on the postgres instance. It vacuums all databases within the instance using the `vacuumdb` command-line tool.

Signed-off-by: David Bond <davidsbond93@gmail.com>