### PR TITLE
Enable dependabot for docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
     directory: /apps
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: /apps/homadctl
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /apps/speed-dial
+    schedule:
+     interval: daily


### PR DESCRIPTION
This commit adds dependabot configuration for homadctl and speed-dial's docker images.

Signed-off-by: David Bond <davidsbond93@gmail.com>