### PR TITLE
Remove unallowed task service field from nomad job specs

### DIFF
--- a/terraform/nomad/jobs/monitoring/home-assistant.nomad
+++ b/terraform/nomad/jobs/monitoring/home-assistant.nomad
@@ -22,7 +22,6 @@ job "homeassistant" {
     service {
       name = "homeassistant"
       port = "homeassistant"
-      task = "homeassistant"
 
       tags = [
         "traefik.enable=true",

--- a/terraform/nomad/jobs/monitoring/prometheus.nomad
+++ b/terraform/nomad/jobs/monitoring/prometheus.nomad
@@ -24,7 +24,6 @@ job "prometheus" {
     service {
       name = "prometheus"
       port = "prometheus"
-      task = "prometheus"
 
       tags = [
         "traefik.enable=true",

--- a/terraform/nomad/jobs/security/bitwarden.nomad
+++ b/terraform/nomad/jobs/security/bitwarden.nomad
@@ -28,7 +28,6 @@ job "bitwarden" {
     service {
       name = "bitwarden"
       port = "bitwarden"
-      task = "bitwarden"
 
       tags = [
         "traefik.enable=true",

--- a/terraform/nomad/jobs/storage/minio.nomad
+++ b/terraform/nomad/jobs/storage/minio.nomad
@@ -32,7 +32,6 @@ job "minio" {
     service {
       name = "minio-api"
       port = "api"
-      task = "minio"
 
       tags = [
         "traefik.enable=true",
@@ -52,7 +51,6 @@ job "minio" {
     service {
       name = "minio-ui"
       port = "ui"
-      task = "minio"
 
       tags = [
         "traefik.enable=true",

--- a/terraform/nomad/jobs/storage/postgres.nomad
+++ b/terraform/nomad/jobs/storage/postgres.nomad
@@ -28,7 +28,6 @@ job "postgres" {
     service {
       name = "postgres"
       port = "postgres"
-      task = "postgres"
 
       tags = [
         "traefik.enable=true",


### PR DESCRIPTION
I upgraded to nomad 1.4.1 and some jobs no longer get evaluated due to the use of the `service.task` field when the checks aren't script or gRPC based checks.

These have now been removed.

Signed-off-by: David Bond <davidsbond93@gmail.com>