### PR TITLE
Don't try to plan for dependabot PRs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,6 +31,7 @@ jobs:
     needs:
       - format
     runs-on: ubuntu-20.04
+    if: ${{ !contains(github.ref, 'dependabot/') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
This commit modifies the terraform workflow to ignore branches that have `dependabot/` in them. I won't be giving secrets to dependabot so this will never work.

Signed-off-by: David Bond <davidsbond93@gmail.com>