### PR TITLE
Switch from deprecated boundary resources & update NAS name

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,7 +31,7 @@ jobs:
     needs:
       - format
     runs-on: ubuntu-20.04
-    if: ${{ !contains(github.ref, 'dependabot/') }}
+    if: (github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'dependabot/')
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0

--- a/terraform/boundary/accounts.tf
+++ b/terraform/boundary/accounts.tf
@@ -3,8 +3,7 @@ resource "random_password" "david" {
   length  = 16
 }
 
-resource "boundary_account" "david" {
-  name           = "david"
+resource "boundary_account_password" "david" {
   type           = "password"
   login_name     = "david"
   password       = random_password.david.result

--- a/terraform/boundary/host_catalogues.tf
+++ b/terraform/boundary/host_catalogues.tf
@@ -1,21 +1,17 @@
-resource "boundary_host_catalog" "homelab" {
+resource "boundary_host_catalog_static" "homelab" {
   name     = "homelab"
-  type     = "static"
   scope_id = boundary_scope.homad.id
 }
 
-resource "boundary_host_set" "homelab" {
-  name            = "homelab"
-  host_catalog_id = boundary_host_catalog.homelab.id
-  type            = "static"
-  host_ids        = [for host in boundary_host.homelab : host.id]
+resource "boundary_host_set_static" "homelab" {
+  host_catalog_id = boundary_host_catalog_static.homelab.id
+  host_ids        = [for host in boundary_host_static.homelab : host.id]
 }
 
-resource "boundary_host" "homelab" {
+resource "boundary_host_static" "homelab" {
   for_each        = var.homelab_servers
   name            = each.key
-  host_catalog_id = boundary_host_catalog.homelab.id
-  type            = "static"
+  host_catalog_id = boundary_host_catalog_static.homelab.id
   address         = each.key
 }
 

--- a/terraform/boundary/targets.tf
+++ b/terraform/boundary/targets.tf
@@ -4,7 +4,7 @@ resource "boundary_target" "homelab" {
   default_port = "22"
   scope_id     = boundary_scope.homad.id
   host_source_ids = [
-    boundary_host_set.homelab.id,
+    boundary_host_set_static.homelab.id,
   ]
   brokered_credential_source_ids = [
     boundary_credential_library_vault.homad.id

--- a/terraform/boundary/users.tf
+++ b/terraform/boundary/users.tf
@@ -1,5 +1,5 @@
 resource "boundary_user" "david" {
   name        = "david"
-  account_ids = [boundary_account.david.id]
+  account_ids = [boundary_account_password.david.id]
   scope_id    = boundary_scope.org.id
 }

--- a/terraform/tailscale/devices.tf
+++ b/terraform/tailscale/devices.tf
@@ -1,5 +1,5 @@
 data "tailscale_device" "nas" {
-  name = "home-nas.davidsbond93.gmail.com"
+  name = "home-nas.tailnet-934e.ts.net"
 }
 
 data "tailscale_devices" "nomad_clients" {


### PR DESCRIPTION
This commit removes the usage of deprecated resources in the boundary provider and updates the tailscale device name for my NAS as they've changed the name format.

Signed-off-by: David Bond <davidsbond93@gmail.com>